### PR TITLE
fix: 著者が登録されていない場合にAPIの取得でエラーとなるバグを修正．ISBNの一致判定でISBN_13が存在しない場合にfatal…

### DIFF
--- a/MyLibrary/Models/Book.swift
+++ b/MyLibrary/Models/Book.swift
@@ -20,7 +20,7 @@ class Book: Identifiable {
     var isbn13: String
     var memo: String
     
-    init(title: String, subtitle: String, authors: [String], bookDescription: String, publishedDate: String, imageUrlString: String, pageCount: Int, isbn13: String, memo: String = "") {
+    init(title: String, subtitle: String, authors: [String], bookDescription: String, publishedDate: String, imageUrlString: String?, pageCount: Int, isbn13: String, memo: String = "") {
         self.id = UUID().uuidString
         self.title = title
         self.subtitle = subtitle
@@ -33,10 +33,14 @@ class Book: Identifiable {
         self.memo = memo
         
         // "http" を "https" に置き換え (こうしないと画像が表示されない)
-        if imageUrlString.hasPrefix("http://") {
-            self.imageUrl = URL(string: imageUrlString.replacingOccurrences(of: "http://", with: "https://"))
+        if let imageUrlString = imageUrlString {
+            if imageUrlString.hasPrefix("http://") {
+                self.imageUrl = URL(string: imageUrlString.replacingOccurrences(of: "http://", with: "https://"))
+            } else {
+                self.imageUrl = URL(string: imageUrlString)
+            }
         } else {
-            self.imageUrl = URL(string: imageUrlString)
+            self.imageUrl = nil
         }
     }
 }

--- a/MyLibrary/Models/FetchedBook.swift
+++ b/MyLibrary/Models/FetchedBook.swift
@@ -17,11 +17,11 @@ struct FetchedBook: Codable {
     struct VolumeInfo: Codable {
         let title: String
         let subtitle: String?
-        let authors: [String]
+        let authors: [String]?
         let publishedDate: String
         let description: String?
         let industryIdentifiers: [IndustryIdentifier]
-        let imageLinks: ImageLinks
+        let imageLinks: ImageLinks?
         let pageCount: Int
     }
     

--- a/MyLibrary/ViewModels/BookViewModel.swift
+++ b/MyLibrary/ViewModels/BookViewModel.swift
@@ -23,16 +23,17 @@ class BookViewModel: ObservableObject {
             let bookItem = response.items[0]  // 検索結果は配列になるが，1件しか取得していないので0番で固定
             
             // 最上位の検索結果が異なる本であった場合は見つからなかったと判定する (API変更の検討の余地あり)
-            if isbn != bookItem.volumeInfo.industryIdentifiers[1].identifier {
+            guard bookItem.volumeInfo.industryIdentifiers.first(where: { $0.type == "ISBN_13" && $0.identifier == isbn }) != nil else {
                 throw NSError(domain: "BookViewModel", code: 0, userInfo: [NSLocalizedDescriptionKey: "入力と異なる本が取得されました"])
             }
+            
             let book = Book(
                         title: bookItem.volumeInfo.title,
                         subtitle: bookItem.volumeInfo.subtitle ?? "",
-                        authors: bookItem.volumeInfo.authors,
+                        authors: bookItem.volumeInfo.authors ?? [],
                         bookDescription: bookItem.volumeInfo.description ?? "",
                         publishedDate: bookItem.volumeInfo.publishedDate,
-                        imageUrlString: bookItem.volumeInfo.imageLinks.thumbnail,  // 高画質のサムネイルのURL
+                        imageUrlString: bookItem.volumeInfo.imageLinks?.thumbnail ?? nil,  // 高画質のサムネイルのURL
                         pageCount: bookItem.volumeInfo.pageCount,
                         isbn13: bookItem.volumeInfo.industryIdentifiers[1].identifier  // 13桁のISBNコード
             )


### PR DESCRIPTION
Google Books APIでは，本によっては著者が登録されていない場合があった．
実装上は，著者は必ず存在するものとして扱ってしまっていたため，著者がいない場合にはkeyErrorとなってしまった．

また，修正後に動作確認をしていたらISBN_13を取得できなかったとき(PKEYのみ取得された)場合にはfatal errorとなったため，ISBNコードの判定部分の修正も行った．

close #7