### PR TITLE
fix: 入力された文字列がISBNコードでない(978から始まらない)場合に警告文を出すように修正．#11

### DIFF
--- a/MyLibrary/Views/ListView.swift
+++ b/MyLibrary/Views/ListView.swift
@@ -125,7 +125,7 @@ extension ListView {
                         print(searchText)
                         
                         guard isValidISBN(searchText) else {
-                            errorMessage = "※ISBNコードは13桁の数字で入力してください"
+                            errorMessage = "※入力されたのはISBNコードではありません。\n978から始まる13桁の数字を入力してください。"
                             return
                         }
                         
@@ -168,7 +168,10 @@ extension ListView {
     // 入力値のチェック (13桁の数字であるかどうかの判定)
     private func isValidISBN(_ searchText: String) -> Bool {
         let regex = #"^\d{13}$"#
-        return searchText.range(of: regex, options: .regularExpression) != nil
+        guard searchText.range(of: regex, options: .regularExpression) != nil else {
+            return false
+        }
+        return searchText.hasPrefix("978")
     }
     
 }


### PR DESCRIPTION
現状のISBNコードは978から始まるものなので，13桁の数字であってもこれを満たさない限り検索しても所望の本は取得できない．
そのため，APIで取得を行う前に警告文を出すように修正した．

close #11 