### PR TITLE
fix: 検索後，BookDetailViewを閉じた後に検索キーワードを消すように修正 #12

### DIFF
--- a/MyLibrary/Views/ListView.swift
+++ b/MyLibrary/Views/ListView.swift
@@ -99,9 +99,11 @@ struct ListView: View {
                 }
             }
         }
-        .sheet(item: $fetchedBook) { book in
+        .sheet(item: $fetchedBook, onDismiss: {
+            searchText = ""
+        }, content: { book in
             BookDetailView(book: book, isNewBook: true, isEditing: true)
-        }
+        })
         .sheet(isPresented: $isOpenScanner) {
             BarcodeScanView(isOpenScanner: $isOpenScanner, fetchedBook: $fetchedBook)
         }


### PR DESCRIPTION
ISBNコードを直接検索し，BookDetailViewを閉じた際に検索キーワードを消すように修正した．

消すタイミングとしては，検索直後(BookDetailViewを開く前)と登録 or キャンセル直後(BookDetailViewを閉じた後)があるが，両方の挙動を試した際に前者の方は検索結果が表示される前にフォームから値が消えるのが不自然に感じた．
そのため，後者のときに消す仕様にした．

close #12