### PR TITLE
feat: 本を削除する際に警告アラートを表示するように実装 #9

### DIFF
--- a/MyLibrary/Views/ListView.swift
+++ b/MyLibrary/Views/ListView.swift
@@ -20,6 +20,7 @@ struct ListView: View {
     @State var fetchedBook: Book?
     @State var errorMessage: String? = nil
     @State var isOpenScanner = false
+    @State var isShowAlert = false
     
     var body: some View {
         NavigationStack {
@@ -88,11 +89,19 @@ struct ListView: View {
                             Spacer()
                             
                             Button(role: .destructive) {
-                                bookViewModel.deleteBooks(selectedBooks: selectedBooks, modelContext: modelContext)
-                                editMode = .inactive
+                                isShowAlert = true
                             } label: {
                                 Text("削除")
                                     .foregroundStyle(.red)
+                            }
+                            .alert("警告", isPresented: $isShowAlert) {
+                                Button("キャンセル", role: .cancel) {}
+                                Button("削除", role: .destructive) {
+                                    bookViewModel.deleteBooks(selectedBooks: selectedBooks, modelContext: modelContext)
+                                    editMode = .inactive
+                                }
+                            } message: {
+                                Text("選択した本を削除します。この操作は取り消せません。")
                             }
                         }
                     }


### PR DESCRIPTION
本の削除は，取り消せない操作であるのでこのような場合にはアラートで確認するべきであると感じた．
そのため，本を選択して「削除」をクリックした後にすぐに削除せずに，確認用に警告アラートを表示するように変更．

close #9 