### PR TITLE
Feature/#17 fix keyboard

### DIFF
--- a/MyLibrary/Views/ListView.swift
+++ b/MyLibrary/Views/ListView.swift
@@ -108,9 +108,6 @@ struct ListView: View {
                 }
             }
         }
-        .onTapGesture {
-            keyboardFocus = false
-        }
         .sheet(item: $fetchedBook, onDismiss: {
             searchText = ""
         }, content: { book in
@@ -123,7 +120,6 @@ struct ListView: View {
 }
 
 #Preview {
-    
     ListView()
         .modelContainer(for: Book.self, inMemory: true)
         .environmentObject(BookViewModel())
@@ -159,6 +155,20 @@ extension ListView {
                                 } catch {
                                     print("検索したISBNの本は見つかりませんでした：\(error)")
                                     fetchedBook = bookViewModel.creareEmptyBook(isbn13: searchText)  // 検索した本が見つからない場合は空の登録フォームを表示する
+                                }
+                            }
+                        }
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .keyboard) {
+                            HStack {
+                                Spacer()
+                                
+                                Button {
+                                    keyboardFocus = false
+                                } label: {
+                                    Text(Image(systemName: "keyboard.chevron.compact.down"))
+                                        .foregroundStyle(Color(uiColor: .label))
                                 }
                             }
                         }


### PR DESCRIPTION
キーボード関連の機能改善として，次の2つの処理を実装した：
- キーボードを開いているときに閉じるためのToolBarを導入
  - 当初は画面をタップしたら閉じるようにしようと思ったが，BookDetailViewを表示するためのNavigationLinkが反応しなくなったので，キーボードに閉じる用のボタンを追加するようにした．
- キーボードを数字のみのものに変更
  - 数字用のキーボードにはsubmitボタンが無いため，13桁入力されたら自動で値のチェックと取得処理を行う仕様にした．
 
close #17  