### PR TITLE
Feature/display date

### DIFF
--- a/MyLibrary/Utils/BookDetail.swift
+++ b/MyLibrary/Utils/BookDetail.swift
@@ -10,6 +10,7 @@ enum BookDetail {
     case description
     case isbn
     case pageCount
+    case publishedDate
 }
 
 extension BookDetail {
@@ -22,6 +23,8 @@ extension BookDetail {
             "barcode"
         case .pageCount:
             "book.pages"
+        case .publishedDate:
+            "calendar"
         }
     }
     
@@ -33,6 +36,8 @@ extension BookDetail {
             "ISBN"
         case .pageCount:
             "ページ数"
+        case .publishedDate:
+            "出版日"
         }
     }
     
@@ -44,6 +49,8 @@ extension BookDetail {
             "本のISBNコード"
         case .pageCount:
             "本のページ数"
+        case .publishedDate:
+            "本の出版日"
         }
     }
     
@@ -51,7 +58,7 @@ extension BookDetail {
         switch self {
         case .description:
             true
-        case .isbn, .pageCount:
+        case .isbn, .pageCount, .publishedDate:
             false
         }
     }

--- a/MyLibrary/ViewModels/BookViewModel.swift
+++ b/MyLibrary/ViewModels/BookViewModel.swift
@@ -9,22 +9,6 @@ import SwiftData
 
 class BookViewModel: ObservableObject {
     
-    init() {
-        let sample1 = "2021-12-31"
-        let sample2 = "2021-12-1"
-        let sample3 = "2021-12"
-        let sample4 = "2021"
-        let sample5 = "2021-2-31"
-        let sample6 = "2021-1-22"
-        
-        print(isValidPublishedDateString(sample1))
-        print(isValidPublishedDateString(sample2))
-        print(isValidPublishedDateString(sample3))
-        print(isValidPublishedDateString(sample4))
-        print(isValidPublishedDateString(sample5))
-        print(isValidPublishedDateString(sample6))
-    }
-    
     // Google Books APIで本の情報を取得し，Bookで返す
     func fetchBook(isbn: String) async throws -> Book {
         let urlString = "https://www.googleapis.com/books/v1/volumes?maxResults=1"  // 最上位の検索結果のみ取得
@@ -115,7 +99,7 @@ class BookViewModel: ObservableObject {
         }
     }
     
-    //
+    // 選択した本の情報をCSV形式に変換し，URLを返す
     func exportBooksToCSV(selectedBooks: Set<String> ,modelContext: ModelContext) -> URL? {
         
         if let csvString = generateCSV(selectedBooks: selectedBooks, modelContext: modelContext) {

--- a/MyLibrary/Views/BookDetailView.swift
+++ b/MyLibrary/Views/BookDetailView.swift
@@ -10,6 +10,8 @@ struct BookDetailView: View {
     
     @Bindable var book: Book
     
+    @State var publishedDateErrorMessage: String = ""
+    
     var isNewBook: Bool = false  // 新規登録であるか
     @State var isEditing: Bool = false // 編集中であるか
     
@@ -30,29 +32,7 @@ struct BookDetailView: View {
                     
                     BookDetailRow(bookDetail: .pageCount, inputText: $book.pageCount, isEditing: isEditing)
                     
-                    // 出版日
-                    HStack(spacing: 10) {
-                        Image(systemName: "calendar")
-                            .imageScale(.large)
-                        
-                        Text("出版日")
-                            .foregroundStyle(.primary)
-                        
-                        Spacer()
-                        
-//                        if isEditing {
-//                            DatePicker("", selection: Binding(
-//                                get: { book.publishedDate ?? Date() },
-//                                set: { newDate in book.publishedDate = newDate }
-//                            ), displayedComponents: .date)
-//                            .datePickerStyle(.compact)
-//                            
-//                        } else {
-//                            Text(book.publishedDate != nil ? formattedDate(book.publishedDate!) : "未指定")
-//                                .lineLimit(nil)
-//                                .foregroundStyle(.secondary)
-//                        }
-                    }
+                    BookDetailRow(bookDetail: .publishedDate, inputText: $book.publishedDate, isEditing: isEditing, errorMessage: publishedDateErrorMessage)
                 }
                 
                 // 自由に記録を残す用のメモ欄
@@ -83,8 +63,14 @@ struct BookDetailView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     if isEditing {
                         Button(isNewBook ? "登録" : "保存") {
-                            isNewBook ? bookViewModel.addBook(book, modelContext: modelContext) : bookViewModel.updateBook(book, modelContext: modelContext)
-                            isNewBook ? dismiss() : isEditing.toggle()
+                            if bookViewModel.isValidPublishedDateString(book.publishedDate) {
+                                publishedDateErrorMessage = ""
+                                isNewBook ? bookViewModel.addBook(book, modelContext: modelContext) : bookViewModel.updateBook(book, modelContext: modelContext)
+                                isNewBook ? dismiss() : isEditing.toggle()
+                                
+                            } else {
+                                publishedDateErrorMessage = "入力値が不正です。"
+                            }
                         }
                     } else {
                         Button("編集") {
@@ -112,14 +98,4 @@ struct BookDetailView: View {
         )
     )
     .modelContainer(for: Book.self, inMemory: true)
-}
-
-extension BookDetailView {
-    
-    private func formattedDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy/MM/dd"
-        return formatter.string(from: date)
-    }
-    
 }

--- a/MyLibrary/Views/Compornents/BookDetailRow.swift
+++ b/MyLibrary/Views/Compornents/BookDetailRow.swift
@@ -11,6 +11,7 @@ struct BookDetailRow: View {
     let bookDetail: BookDetail
     @Binding var inputText: String
     let isEditing: Bool
+    var errorMessage = ""
     
     var body: some View {
         HStack(spacing: 10) {
@@ -23,8 +24,23 @@ struct BookDetailRow: View {
             Spacer()
             
             if isEditing {
-                TextField(bookDetail.textFieldText, text: $inputText, axis: .vertical)
-                    .lineLimit(bookDetail.permitNewline ? nil : 1)
+                VStack(alignment: .leading) {
+                    TextField(bookDetail.textFieldText, text: $inputText, axis: .vertical)
+                        .lineLimit(bookDetail.permitNewline ? nil : 1)
+                        .multilineTextAlignment(bookDetail.permitNewline ? .leading : .trailing)
+                    
+                    if bookDetail == .publishedDate {
+                        Text("※日付は yyyy-MM-dd, yyyy-MM, yyyy 形式のいずれかで入力")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    
+                    if !errorMessage.isEmpty {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
             } else {
                 Text(inputText)
                     .lineLimit(bookDetail.permitNewline ? nil : 1)
@@ -36,5 +52,5 @@ struct BookDetailRow: View {
 
 #Preview {
     @Previewable @State var inputText: String = "テキスト"
-    BookDetailRow(bookDetail: .description, inputText: $inputText, isEditing: false)
+    BookDetailRow(bookDetail: .publishedDate, inputText: $inputText, isEditing: true)
 }


### PR DESCRIPTION
BookDetailViewで出版日を表示・入力するための機能を実装．

Google Books APIでは，出版日の情報はyyyy, yyyy-MM, yyyy-MM-dd形式のいずれかで保存されている．
つまり，異なる日付の形式が共存している状況である．
本来はDate型で管理するべきであるが，形式が一意でないので困難である．

そこで，今回は保存時に3種類の形式と空欄のみを許可するように入力値のチェックを行うことで不正な出版日にならないように対策した．